### PR TITLE
Allow for specifying the docker hub repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN yarn --pure-lockfile install
 ENV ROUTER_BASE="/dashboard"
 RUN yarn run build --spa
 
-FROM rancher/rancher:<VERSION>
+FROM <REPOSITORY>:<VERSION>
 WORKDIR /var/lib/rancher
 RUN rm -rf /usr/share/rancher/ui-dashboard/dashboard*
 COPY --from=builder /src/dist /usr/share/rancher/ui-dashboard/dashboard

--- a/cloud-config-min
+++ b/cloud-config-min
@@ -15,5 +15,5 @@ system_info:
     groups: [docker]
 
 runcmd:
-  - "docker run -d --restart unless-stopped --privileged -p 80:80 -p 443:443 -e CATTLE_BOOTSTRAP_PASSWORD=<RANCHER_BOOTSTRAP_PASSWORD> rancher/rancher:<RANCHER_VERSION>"
+  - "docker run -d --restart unless-stopped --privileged -p 80:80 -p 443:443 -e CATTLE_BOOTSTRAP_PASSWORD=<RANCHER_BOOTSTRAP_PASSWORD> <DOCKER_HUB_REPOSITORY>:<RANCHER_VERSION>"
   - "echo $(date) ': Time to do the stuff'"

--- a/cloud-config-tmp
+++ b/cloud-config-tmp
@@ -18,6 +18,7 @@ runcmd:
   - "mkdir -p /run/dockerfiles"
   - "wget https://raw.githubusercontent.com/rak-phillip/digital-ocean-droplet-rancher/main/Dockerfile -P /run/dockerfiles/"
   - "sed -i 's/<VERSION>/<RANCHER_VERSION>/g' /run/dockerfiles/Dockerfile"
+  - "sed -i 's/<REPOSITORY>/<DOCKER_HUB_REPOSITORY>/g' /run/dockerfiles/Dockerfile"
   - "git clone --branch <REPO_BRANCH> <REPO_URL> /run/dashboard"
   - "cd /run/dashboard"
   - "docker build -f /run/dockerfiles/Dockerfile -t <REPO_BRANCH> ."

--- a/cloud.go
+++ b/cloud.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"embed"
 	"fmt"
 	"io/ioutil"
 	"strings"
-	"embed"
 )
 
 //go:embed cloud-config-tmp cloud-config-min
@@ -29,6 +29,7 @@ func updateDoConfig(fileString string, config *doConfig) {
 	f = strings.Replace(f, "<REPO_BRANCH>", config.branch, -1)
 	f = strings.Replace(f, "<REPO_URL>", config.url, 1)
 	f = strings.Replace(f, "<RANCHER_VERSION>", config.rancherVersion, 1)
+	f = strings.Replace(f, "<DOCKER_HUB_REPOSITORY>", config.repository, 1)
 	f = strings.Replace(f, "<RANCHER_BOOTSTRAP_PASSWORD>", config.bootstrapPassword, 1)
 
 	data := []byte(f)

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	app := &cli.App{
 		Name:    "dorm (Digital Ocean Rancher Manager)",
-		Version: "v0.0.3",
+		Version: "v0.0.4",
 		Authors: []*cli.Author{
 			{
 				Name:  "Phillip Rak",

--- a/main.go
+++ b/main.go
@@ -83,8 +83,8 @@ func main() {
 			&cli.StringFlag{
 				Name:        "rancher-version",
 				Usage:       "Target version of Rancher",
-				Value:       "v2.7-head",
-				DefaultText: "v2.7-head",
+				Value:       "v2.8.2",
+				DefaultText: "v2.8.2",
 				Destination: &config.rancherVersion,
 			},
 			&cli.StringFlag{

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ type doConfig struct {
 	rancherVersion    string
 	bootstrapPassword string
 	useMinConfig      bool
+	repository        string
 }
 
 const (
@@ -91,6 +92,13 @@ func main() {
 				Usage:       "Bootstrap password for Rancher",
 				Value:       uuid.New().String(),
 				Destination: &config.bootstrapPassword,
+			},
+			&cli.StringFlag{
+				Name:        "repository",
+				Usage:       "The name of the Docker repository on Docker Hub",
+				Value:       "rancher/rancher",
+				DefaultText: "rancher/rancher",
+				Destination: &config.repository,
 			},
 		},
 		Action: func(c *cli.Context) error {


### PR DESCRIPTION
There might be situations where the rancher image is published to a repository other than `rancher/rancher` on docker hub. This allows for specifying the repository via a flag. 